### PR TITLE
fix(parser): handle excused final grades

### DIFF
--- a/src/main/kotlin/me/tomasan7/jecnaapi/data/grade/FinalGrade.kt
+++ b/src/main/kotlin/me/tomasan7/jecnaapi/data/grade/FinalGrade.kt
@@ -42,4 +42,10 @@ sealed interface FinalGrade
      */
     @Serializable
     data object GradesAndAbsenceWarning : FinalGrade
+
+    /**
+     * Student is excused from the subject. (U)
+     */
+    @Serializable
+    data object Excused: FinalGrade
 }

--- a/src/main/kotlin/me/tomasan7/jecnaapi/parser/parsers/HtmlGradesPageParserImpl.kt
+++ b/src/main/kotlin/me/tomasan7/jecnaapi/parser/parsers/HtmlGradesPageParserImpl.kt
@@ -133,6 +133,8 @@ internal object HtmlGradesPageParserImpl : HtmlGradesPageParser
     {
         val textContent = finalGradeEle.text()
 
+        if (textContent == "U") return FinalGrade.Excused
+
         return if (finalGradeEle.hasClass("scoreValueWarning"))
             when (textContent)
             {


### PR DESCRIPTION
- Introduce `FinalGrade.Excused` for excused subjects.
- Map any final grade with text content "U" to this new object.

This change will be reflected in JecnaMobile in my next PR on JecnaMobile repo.