### PR TITLE
feature/documents

### DIFF
--- a/jecnaapi-java/src/jvmMain/kotlin/io/github/tomhula/jecnaapi/java/JecnaClientJavaWrapper.kt
+++ b/jecnaapi-java/src/jvmMain/kotlin/io/github/tomhula/jecnaapi/java/JecnaClientJavaWrapper.kt
@@ -62,7 +62,9 @@ class JecnaClientJavaWrapper(autoLogin: Boolean = false)
     fun getNotifications() = GlobalScope.future { wrappedClient.getNotifications() }
     fun getRoomsPage() = GlobalScope.future { wrappedClient.getRoomsPage() }
     fun getRoom(roomReference: RoomReference) = GlobalScope.future { wrappedClient.getRoom(roomReference) }
-    fun getRoom(roomCode: String) = GlobalScope.future { wrappedClient.getRoom(roomCode) } 
+    fun getRoom(roomCode: String) = GlobalScope.future { wrappedClient.getRoom(roomCode) }
+    fun getDocumentsPage() = GlobalScope.future { wrappedClient.getDocumentsPage() }
+    fun getDocumentsPage(path: String) = GlobalScope.future { wrappedClient.getDocumentsPage(path) }
 
     /** A query without any authentication (autologin) handling. */
     fun plainQuery(path: String, parameters: Parameters? = null) =

--- a/src/commonMain/kotlin/io/github/tomhula/jecnaapi/JecnaClient.kt
+++ b/src/commonMain/kotlin/io/github/tomhula/jecnaapi/JecnaClient.kt
@@ -1,4 +1,6 @@
 package io.github.tomhula.jecnaapi
+
+import io.github.tomhula.jecnaapi.data.document.DocumentsPage
 import io.github.tomhula.jecnaapi.data.absence.AbsencesPage
 import io.github.tomhula.jecnaapi.data.article.NewsPage
 import io.github.tomhula.jecnaapi.data.attendance.AttendancesPage
@@ -52,6 +54,7 @@ interface JecnaClient
 
     /** @return the list of student's certificates or `null` if the student cannot have any certificates (i.e. he is not in the 4th grade) */
     suspend fun getStudentCertificates(): List<Certificate>?
+    suspend fun getDocumentsPage(path: String = "/dokumenty"): DocumentsPage
     
     companion object
     {

--- a/src/commonMain/kotlin/io/github/tomhula/jecnaapi/WebJecnaClient.kt
+++ b/src/commonMain/kotlin/io/github/tomhula/jecnaapi/WebJecnaClient.kt
@@ -174,7 +174,13 @@ class WebJecnaClient(
     override suspend fun getNotifications() = notificationParser.parse(queryStringBody(PageWebPath.NOTIFICATIONS))
     override suspend fun getStudentCertificates(): List<Certificate>?
     {
-        return certificatePageParser.parse(queryStringBody(PageWebPath.CERTIFICATES))
+        val response = query(PageWebPath.CERTIFICATES)
+        val locationHeader = response.headers[HttpHeaders.Location]
+
+        if (locationHeader == "$endpoint/neopravneny-pristup")
+            return null
+
+        return certificatePageParser.parse(response.bodyAsText())
     }
 
     override suspend fun getDocumentsPage(path: String): DocumentsPage =

--- a/src/commonMain/kotlin/io/github/tomhula/jecnaapi/WebJecnaClient.kt
+++ b/src/commonMain/kotlin/io/github/tomhula/jecnaapi/WebJecnaClient.kt
@@ -182,9 +182,7 @@ class WebJecnaClient(
 
         return certificatePageParser.parse(response.bodyAsText())
     }
-
-    override suspend fun getDocumentsPage(path: String): DocumentsPage =
-        documentsPageParser.parse(queryStringBody(path))
+    override suspend fun getDocumentsPage(path: String): DocumentsPage = documentsPageParser.parse(queryStringBody(path))
 
     suspend fun setRole(role: Role)
     {

--- a/src/commonMain/kotlin/io/github/tomhula/jecnaapi/WebJecnaClient.kt
+++ b/src/commonMain/kotlin/io/github/tomhula/jecnaapi/WebJecnaClient.kt
@@ -3,6 +3,7 @@ package io.github.tomhula.jecnaapi
 import com.fleeksoft.ksoup.Ksoup
 import com.fleeksoft.ksoup.nodes.Document
 import io.github.tomhula.jecnaapi.data.cert.Certificate
+import io.github.tomhula.jecnaapi.data.document.DocumentsPage
 import io.github.tomhula.jecnaapi.data.notification.NotificationReference
 import io.github.tomhula.jecnaapi.parser.parsers.*
 import io.github.tomhula.jecnaapi.util.JecnaPeriodEncoder
@@ -92,6 +93,7 @@ class WebJecnaClient(
     private val roomsPageParser = RoomsPageParser
     private val roomParser = RoomParser(TimetableParser)
     private val certificatePageParser = CertificatePageParser
+    private val documentsPageParser = DocumentsPageParser
 
     @OptIn(ExperimentalTime::class)
     override suspend fun login(auth: Auth): Boolean
@@ -172,14 +174,11 @@ class WebJecnaClient(
     override suspend fun getNotifications() = notificationParser.parse(queryStringBody(PageWebPath.NOTIFICATIONS))
     override suspend fun getStudentCertificates(): List<Certificate>?
     {
-        val response = query(PageWebPath.CERTIFICATES)
-        val locationHeader = response.headers[HttpHeaders.Location]
-
-        if (locationHeader == "$endpoint/neopravneny-pristup")
-            return null
-        
-        return certificatePageParser.parse(response.bodyAsText())
+        return certificatePageParser.parse(queryStringBody(PageWebPath.CERTIFICATES))
     }
+
+    override suspend fun getDocumentsPage(path: String): DocumentsPage =
+        documentsPageParser.parse(queryStringBody(path))
 
     suspend fun setRole(role: Role)
     {

--- a/src/commonMain/kotlin/io/github/tomhula/jecnaapi/data/document/SchoolDocument.kt
+++ b/src/commonMain/kotlin/io/github/tomhula/jecnaapi/data/document/SchoolDocument.kt
@@ -6,18 +6,19 @@ import kotlinx.serialization.Serializable
 sealed class SchoolDocument
 {
     abstract val label: String
+    abstract val path: String
 }
 
 @Serializable
 data class DocumentFolder(
     override val label: String,
-    val path: String
+    override val path: String
 ) : SchoolDocument()
 
 @Serializable
 data class DocumentFile(
     override val label: String,
-    val downloadPath: String
+    override val path: String
 ) : SchoolDocument()
 
 @Serializable

--- a/src/commonMain/kotlin/io/github/tomhula/jecnaapi/data/document/SchoolDocument.kt
+++ b/src/commonMain/kotlin/io/github/tomhula/jecnaapi/data/document/SchoolDocument.kt
@@ -24,5 +24,6 @@ data class DocumentFile(
 @Serializable
 data class DocumentsPage(
     val path: String,
+    val parentPath: String? = null,
     val documents: List<SchoolDocument>
 )

--- a/src/commonMain/kotlin/io/github/tomhula/jecnaapi/data/document/SchoolDocument.kt
+++ b/src/commonMain/kotlin/io/github/tomhula/jecnaapi/data/document/SchoolDocument.kt
@@ -1,0 +1,27 @@
+package io.github.tomhula.jecnaapi.data.document
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+sealed class SchoolDocument
+{
+    abstract val label: String
+}
+
+@Serializable
+data class DocumentFolder(
+    override val label: String,
+    val path: String
+) : SchoolDocument()
+
+@Serializable
+data class DocumentFile(
+    override val label: String,
+    val downloadPath: String
+) : SchoolDocument()
+
+@Serializable
+data class DocumentsPage(
+    val path: String,
+    val documents: List<SchoolDocument>
+)

--- a/src/commonMain/kotlin/io/github/tomhula/jecnaapi/parser/parsers/DocumentsPageParser.kt
+++ b/src/commonMain/kotlin/io/github/tomhula/jecnaapi/parser/parsers/DocumentsPageParser.kt
@@ -21,11 +21,24 @@ internal object DocumentsPageParser
                 ?.trim()
                 ?: "/dokumenty"
 
+            val parentPath = document
+                .select("ul.documents a.dir")
+                .firstOrNull { link ->
+                    val label = link.selectFirst(".label")
+                        ?.text()
+                        ?.replace("\u00A0", " ")
+                        ?: return@firstOrNull false
+
+                    label == ".."
+                }
+                ?.attr("href")
+                ?.takeIf { it.isNotBlank() }
+
             val documents = document
                 .select("ul.documents a.dir, ul.documents a.file")
                 .mapNotNull { parseDocument(it) }
 
-            return DocumentsPage(path, documents)
+            return DocumentsPage(path = path, parentPath = parentPath, documents = documents)
         } catch (e: Exception)
         {
             throw ParseException("Failed to parse documents page.", e)

--- a/src/commonMain/kotlin/io/github/tomhula/jecnaapi/parser/parsers/DocumentsPageParser.kt
+++ b/src/commonMain/kotlin/io/github/tomhula/jecnaapi/parser/parsers/DocumentsPageParser.kt
@@ -1,11 +1,9 @@
 package io.github.tomhula.jecnaapi.parser.parsers
 
 import com.fleeksoft.ksoup.Ksoup
-import com.fleeksoft.ksoup.nodes.Element
 import io.github.tomhula.jecnaapi.data.document.DocumentFile
 import io.github.tomhula.jecnaapi.data.document.DocumentFolder
 import io.github.tomhula.jecnaapi.data.document.DocumentsPage
-import io.github.tomhula.jecnaapi.data.document.SchoolDocument
 import io.github.tomhula.jecnaapi.parser.ParseException
 
 internal object DocumentsPageParser
@@ -21,46 +19,35 @@ internal object DocumentsPageParser
                 ?.trim()
                 ?: "/dokumenty"
 
-            val parentPath = document
-                .select("ul.documents a.dir")
-                .firstOrNull { link ->
-                    val label = link.selectFirst(".label")
-                        ?.text()
-                        ?.replace("\u00A0", " ")
-                        ?: return@firstOrNull false
-
-                    label == ".."
-                }
-                ?.attr("href")
-                ?.takeIf { it.isNotBlank() }
-
+            var parentPath: String? = null
             val documents = document
                 .select("ul.documents a.dir, ul.documents a.file")
-                .mapNotNull { parseDocument(it) }
+                .mapNotNull { linkElement ->
+                    val label = linkElement.selectFirst(".label")
+                        ?.text()
+                        ?.replace("\u00A0", " ")
+                        ?: return@mapNotNull null
+
+                    val href = linkElement.attr("href")
+
+                    if (label == "..")
+                    {
+                        parentPath = href.takeIf { it.isNotBlank() }
+                        return@mapNotNull null
+                    }
+
+                    when
+                    {
+                        linkElement.hasClass("dir") -> DocumentFolder(label, href)
+                        linkElement.hasClass("file") -> DocumentFile(label, href)
+                        else -> null
+                    }
+                }
 
             return DocumentsPage(path = path, parentPath = parentPath, documents = documents)
         } catch (e: Exception)
         {
             throw ParseException("Failed to parse documents page.", e)
-        }
-    }
-
-    private fun parseDocument(linkElement: Element): SchoolDocument?
-    {
-        val label = linkElement.selectFirst(".label")
-            ?.text()
-            ?.replace("\u00A0", " ")
-            ?: return null
-
-        if (label == "..") return null
-
-        val href = linkElement.attr("href")
-
-        return when
-        {
-            linkElement.hasClass("dir") -> DocumentFolder(label, href)
-            linkElement.hasClass("file") -> DocumentFile(label, href)
-            else -> null
         }
     }
 }

--- a/src/commonMain/kotlin/io/github/tomhula/jecnaapi/parser/parsers/DocumentsPageParser.kt
+++ b/src/commonMain/kotlin/io/github/tomhula/jecnaapi/parser/parsers/DocumentsPageParser.kt
@@ -25,6 +25,7 @@ internal object DocumentsPageParser
                 .mapNotNull { linkElement ->
                     val label = linkElement.selectFirst(".label")
                         ?.text()
+                        // Replace non-breaking space with regular space
                         ?.replace("\u00A0", " ")
                         ?: return@mapNotNull null
 

--- a/src/commonMain/kotlin/io/github/tomhula/jecnaapi/parser/parsers/DocumentsPageParser.kt
+++ b/src/commonMain/kotlin/io/github/tomhula/jecnaapi/parser/parsers/DocumentsPageParser.kt
@@ -1,0 +1,53 @@
+package io.github.tomhula.jecnaapi.parser.parsers
+
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Element
+import io.github.tomhula.jecnaapi.data.document.DocumentFile
+import io.github.tomhula.jecnaapi.data.document.DocumentFolder
+import io.github.tomhula.jecnaapi.data.document.DocumentsPage
+import io.github.tomhula.jecnaapi.data.document.SchoolDocument
+import io.github.tomhula.jecnaapi.parser.ParseException
+
+internal object DocumentsPageParser
+{
+    fun parse(html: String): DocumentsPage
+    {
+        try
+        {
+            val document = Ksoup.parse(html)
+            val path = document.selectFirst(".documentPath")
+                ?.text()
+                ?.removePrefix("Adresa:")
+                ?.trim()
+                ?: "/dokumenty"
+
+            val documents = document
+                .select("ul.documents a.dir, ul.documents a.file")
+                .mapNotNull { parseDocument(it) }
+
+            return DocumentsPage(path, documents)
+        } catch (e: Exception)
+        {
+            throw ParseException("Failed to parse documents page.", e)
+        }
+    }
+
+    private fun parseDocument(linkElement: Element): SchoolDocument?
+    {
+        val label = linkElement.selectFirst(".label")
+            ?.text()
+            ?.replace("\u00A0", " ")
+            ?: return null
+
+        if (label == "..") return null
+
+        val href = linkElement.attr("href")
+
+        return when
+        {
+            linkElement.hasClass("dir") -> DocumentFolder(label, href)
+            linkElement.hasClass("file") -> DocumentFile(label, href)
+            else -> null
+        }
+    }
+}


### PR DESCRIPTION
Add the ability to fetch and parse the school documents, subfolders, and files. Example usage:
runBlocking {
            val client = JecnaClient()
            client.login(username, password)
            val visited = mutableSetOf<String>()

            suspend fun walk(path: String, depth: Int = 0) {
                if (!visited.add(path)) return

                val page = client.getDocumentsPage(path)
                val indent = "  ".repeat(depth)

                println("${indent}PATH: ${page.path}")

                for (document: SchoolDocument in page.documents) {
                    when (document) {
                        is DocumentFolder -> {
                            println("${indent}[DIRECTORY] ${document.label} -> ${document.path}")
                            walk(document.path, depth + 1)
                        }
                        is DocumentFile -> {
                            println("${indent}[FILE] ${document.label} -> ${document.downloadPath}")
                        }
                    }
                }
            }
            walk("/dokumenty/")
        }
