### PR TITLE
fix: Make canteen food regex support misspelt delimiter

### DIFF
--- a/jecnaapi-canteen/src/commonMain/kotlin/io/github/tomhula/jecnaapi/parser/parsers/CanteenParser.kt
+++ b/jecnaapi-canteen/src/commonMain/kotlin/io/github/tomhula/jecnaapi/parser/parsers/CanteenParser.kt
@@ -203,7 +203,7 @@ internal object CanteenParser
     /**
      * Matches the whole item description. Match contains capturing groups listed in [ItemDescriptionRegexGroups].
      */
-    private val ITEM_DESCRIPTION_REGEX = Regex("""^(?<${ItemDescriptionRegexGroups.SOUP}>.*?), ;(?<${ItemDescriptionRegexGroups.REST}>.*)""")
+    private val ITEM_DESCRIPTION_REGEX = Regex("""^(?<${ItemDescriptionRegexGroups.SOUP}>.*?),? ;(?<${ItemDescriptionRegexGroups.REST}>.*)""")
 
     /**
      * Contains names of regex capture groups inside [ITEM_DESCRIPTION_REGEX].


### PR DESCRIPTION
Now the delimiter can be either `, ;` or ` ;` cuz they can't write

<img width="272" height="67" alt="image" src="https://github.com/user-attachments/assets/42b8195c-f1d5-470e-b85c-c15f901c008e" />
<img width="351" height="32" alt="image" src="https://github.com/user-attachments/assets/02112757-1df5-4c7b-9460-e8aaec513c6f" />
